### PR TITLE
storageDataGroup: Support writing larger data groups

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "atg-storage",
+  "name": "@f5devcentral/atg-storage",
   "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -3456,6 +3456,12 @@
           }
         }
       }
+    },
+    "mock-fs": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.13.0.tgz",
+      "integrity": "sha512-DD0vOdofJdoaRNtnWcrXe6RQbpHkPPmtqGq14uRX0F8ZKJ5nv89CVTYl/BZdppDxBDaV0hl75htg3abpEWlPZA==",
+      "dev": true
     },
     "ms": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "chai-as-promised": "^7.1.1",
     "eslint": "^6.8.0",
     "mocha": "^6.2.3",
+    "mock-fs": "^4.13.0",
     "nyc": "^15.0.1",
     "sinon": "^7.5.0",
     "stryker-cli": "^1.0.0"

--- a/src/storageDataGroup.js
+++ b/src/storageDataGroup.js
@@ -2,6 +2,7 @@
 
 const http = require('http');
 const zlib = require('zlib');
+const fs = require('fs');
 
 const childProcess = require('child_process');
 
@@ -73,16 +74,49 @@ function addDataGroup(path) {
     return executeCommand(`tmsh -a create ltm data-group internal ${path} type string`);
 }
 
+function deleteDataGroup(path) {
+    return executeCommand(`tmsh -a delete ltm data-group internal ${path}`);
+}
+
 function updateDataGroup(path, records) {
     const tmshRecords = records
         .map(record => `${record.name} { data ${record.data} }`)
-        .join(' ');
-    // eslint-disable-next-line max-len
-    let command = `tmsh -a modify ltm data-group internal ${path} records replace-all-with { ${tmshRecords} }`;
+        .join('\n        ')
+        .replace(/{ /g, '{\n            ')
+        .replace(/ }/g, '\n        }');
+
     if (tmshRecords === '') {
-        command = `tmsh -a delete ltm data-group internal ${path}`;
+        return deleteDataGroup(path);
     }
-    return executeCommand(command);
+    const configFileName = '/tmp/__atg-storage_temp.conf';
+    const configData = [
+        `ltm data-group internal ${path} {`,
+        '    records {',
+        `        ${tmshRecords}`,
+        '    }',
+        '    type string',
+        '}'
+    ].join('\n');
+
+    return Promise.resolve()
+        .then(() => new Promise((resolve, reject) => {
+            fs.writeFile(configFileName, configData, (err) => {
+                if (err) {
+                    return reject(err);
+                }
+                return resolve();
+            });
+        }))
+        .then(() => deleteDataGroup(path))
+        .then(() => executeCommand(`tmsh -a load sys config merge file ${configFileName}`))
+        .then(() => new Promise((resolve, reject) => {
+            fs.unlink(configFileName, (err) => {
+                if (err) {
+                    return reject(err);
+                }
+                return resolve();
+            });
+        }));
 }
 
 function readDataGroup(path) {

--- a/test/storageDataGroup.js
+++ b/test/storageDataGroup.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const childProcess = require('child_process');
+const fs = require('fs');
 
 const chai = require('chai');
 const chaiAsPromised = require('chai-as-promised');
@@ -71,6 +72,7 @@ describe('StorageDataGroup', () => {
                     throw new Error('data group was not created before delete command');
                 }
                 isDataGroupCreated = false;
+                data = '';
                 callback();
             },
             'modify ltm data-group': (callback, command) => {
@@ -97,6 +99,18 @@ describe('StorageDataGroup', () => {
                     '}'
                 ]).join('\n');
 
+                callback();
+            },
+            'load sys config merge file': (callback, command) => {
+                if (isDataGroupCreated) {
+                    throw new Error('data group already exists');
+                }
+                const filePath = command.split('merge file ')[1];
+                assert(filePath, `got bad load sys config merge file command ${command}`);
+
+                data = fs.readFileSync(filePath, { encoding: 'utf8' });
+
+                isDataGroupCreated = true;
                 callback();
             }
         };

--- a/test/storageDataGroup.js
+++ b/test/storageDataGroup.js
@@ -3,6 +3,7 @@
 const childProcess = require('child_process');
 const fs = require('fs');
 
+const mockfs = require('mock-fs');
 const chai = require('chai');
 const chaiAsPromised = require('chai-as-promised');
 const sinon = require('sinon');
@@ -115,6 +116,10 @@ describe('StorageDataGroup', () => {
             }
         };
 
+        mockfs({
+            '/tmp': {}
+        });
+
         sinon.stub(childProcess, 'exec').callsFake((command, callback) => {
             let foundCmd = false;
             let commands = overrideCommands;
@@ -138,6 +143,7 @@ describe('StorageDataGroup', () => {
         tmshCommands = {};
         overrideCommands = null;
         sinon.restore();
+        mockfs.restore();
     });
 
     generateCommonTests(createStorage, 'common, with cache');


### PR DESCRIPTION
Previously we were constrained by how much data we could enter into the
CLI. Now we use a file and "tmsh load sys config merge" to get around
this limitation.