### PR TITLE
storageDataGroup: Fix maxBuffer option in executeCommand()

### DIFF
--- a/src/storageDataGroup.js
+++ b/src/storageDataGroup.js
@@ -52,7 +52,7 @@ function recordsToString(records, baseKey, offset) {
 
 function executeCommand(command) {
     const options = {
-        maxBufferSize: Infinity
+        maxBuffer: Infinity
     };
     return new Promise((resolve, reject) => {
         childProcess.exec(command, options, (error, stdout, stderr) => {

--- a/test/storageDataGroup.js
+++ b/test/storageDataGroup.js
@@ -127,7 +127,7 @@ describe('StorageDataGroup', () => {
         });
 
         sinon.stub(childProcess, 'exec').callsFake((command, options, callback) => {
-            assert.equal(options.maxBufferSize, Infinity);
+            assert.equal(options.maxBuffer, Infinity);
             let foundCmd = false;
             let commands = overrideCommands;
             if (!commands) {


### PR DESCRIPTION
This was incorrectly using "maxBufferSize" instead of "maxBuffer"