### PR TITLE
storageDataGroup: Make temp data group config filename more unique to avoid collisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ## Added
 - Add StorageJsonFile storage backend to persist on disk using JSON
+- Fix collisions with multiple, concurrent data group writes
 
 ## [1.0.2] - 2020-12-21
 ### Fixed

--- a/src/storageDataGroup.js
+++ b/src/storageDataGroup.js
@@ -3,6 +3,9 @@
 const http = require('http');
 const zlib = require('zlib');
 const fs = require('fs');
+const pathLib = require('path');
+const os = require('os');
+const crypto = require('crypto');
 
 const childProcess = require('child_process');
 
@@ -108,7 +111,8 @@ function updateDataGroup(path, records) {
     if (tmshRecords === '') {
         return deleteDataGroup(path);
     }
-    const configFileName = '/tmp/__atg-storage_temp.conf';
+    const randBytes = crypto.randomBytes(16).toString('hex');
+    const configFileName = pathLib.join(os.tmpdir(), `atg-storage.${randBytes}.conf`);
     const configData = [
         `ltm data-group internal ${path} {`,
         '    records {',


### PR DESCRIPTION
This fixes `/tmp/__atg-storage_temp.conf` not being found when multiple, concurrent writes occur.