### PR TITLE
StorageDataGroup: Fix some security concerns with temporary file usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## Fixed
+- Fix some security concerns with temporary file usage in StorageDataGroup
 
 ## [1.1.0] - 2020-5-6
 ## Added

--- a/src/storageDataGroup.js
+++ b/src/storageDataGroup.js
@@ -112,7 +112,7 @@ function updateDataGroup(path, records) {
         return deleteDataGroup(path);
     }
     const randBytes = crypto.randomBytes(16).toString('hex');
-    const configFileName = pathLib.join(os.tmpdir(), `atg-storage.${randBytes}.conf`);
+    const configFileName = pathLib.join(os.tmpdir(), `tmp${randBytes}.conf`);
     const configData = [
         `ltm data-group internal ${path} {`,
         '    records {',
@@ -124,7 +124,7 @@ function updateDataGroup(path, records) {
 
     return Promise.resolve()
         .then(() => new Promise((resolve, reject) => {
-            fs.writeFile(configFileName, configData, (err) => {
+            fs.writeFile(configFileName, configData, { mode: 0o600, flag: 'wx' }, (err) => {
                 if (err) {
                     return reject(err);
                 }


### PR DESCRIPTION
* Use a less predictable name (no longer contains *atg-storage*)
* Use mode 0o600 on the temporary file
* Error if the temporary file already exists

See https://owasp.org/www-community/vulnerabilities/Insecure_Temporary_File
for more information. Unfortunately, the NodeJS standard library does
not contain a mkstemp() equivalent.