### PR TITLE
No cache for writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.3.0]
+## Changed
+- Always save data to data group on write in StorageDataGroup
+
+## [1.2.0]
+## Added
+- clearCache method
 ## Fixed
 - Fix some security concerns with temporary file usage in StorageDataGroup
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@f5devcentral/atg-storage",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@f5devcentral/atg-storage",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "author": "F5 Networks",
   "license": "Apache-2.0",
   "main": "index.js",

--- a/src/storageDataGroup.js
+++ b/src/storageDataGroup.js
@@ -311,7 +311,6 @@ class StorageDataGroup {
                         acc[curr.name] = curr;
                         return acc;
                     }, {});
-                    return Promise.resolve();
                 }
                 if (records.length === 0) {
                     this._ready = false;
@@ -337,7 +336,6 @@ class StorageDataGroup {
                         acc[curr.name] = curr;
                         return acc;
                     }, {});
-                    return Promise.resolve();
                 }
 
                 return updateDataGroup(this.path, records);

--- a/test/storageDataGroup.js
+++ b/test/storageDataGroup.js
@@ -224,6 +224,9 @@ describe('StorageDataGroup', () => {
             tmshCommands['list ltm data-group'] = (callback) => {
                 callback(null, data);
             };
+            tmshCommands['delete ltm data-group'] = (callback) => {
+                callback();
+            };
 
             return Promise.resolve()
                 .then(() => assert.isFulfilled(
@@ -233,13 +236,25 @@ describe('StorageDataGroup', () => {
 
         it('should block from running init if it is already running', () => {
             const storage = createStorage();
+            const data = [
+                'ltm data-group internal /storage/data-store {',
+                '}'
+            ].join('\n');
 
-            return assert.isFulfilled(
-                Promise.all([
-                    storage.setItem('hello', 'world'),
-                    storage.setItem('foo', 'bar')
-                ])
-            );
+            tmshCommands['list ltm data-group'] = (callback) => {
+                callback(null, data);
+            };
+
+            const ensureFolderSpy = sinon.stub(storage, 'ensureFolder').resolves();
+            const ensureDataGroupSpy = sinon.stub(storage, 'ensureDataGroup').resolves();
+            return Promise.all([
+                storage._getData(),
+                storage._getData()
+            ])
+                .then(() => {
+                    assert.ok(ensureFolderSpy.calledOnce);
+                    assert.ok(ensureDataGroupSpy.calledOnce);
+                });
         });
     });
 


### PR DESCRIPTION
This is to resolve a problem where data is set or deleted and then restnoded restarts before `persist` is called. We do not want to leave it up to the caller to know that they should call `persist` after modifying the data in storage.