### PR TITLE
Remove cache logic from DataGroup persist

### DIFF
--- a/src/storageDataGroup.js
+++ b/src/storageDataGroup.js
@@ -379,23 +379,6 @@ class StorageDataGroup {
         }
 
         return Promise.resolve()
-            .then(() => {
-                if (this.cache) {
-                    return Promise.resolve()
-                        .then(() => this._getRecords())
-                        .then((records) => {
-                            if (records.length === 0) {
-                                this._ready = false;
-                            }
-                            return Promise.resolve(records);
-                        })
-                        .then(records => updateDataGroup(this.path, records))
-                        .then(() => {
-                            this.cache = {};
-                        });
-                }
-                return Promise.resolve();
-            })
             .then(() => new Promise((resolve, reject) => {
                 const req = http.request(opts, (res) => {
                     const buffer = [];


### PR DESCRIPTION
Removing the StorageDataGroup's cache specific logic in persist should speed up saving and remove the need to rebuild the cache - which is sometimes taking more than a minute.
