### PR TITLE
fix: only delete data-group if it exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.X.X] - 2022-X-XX
 ## Changed
 - Updated the release process documentation
+- Fix race condition where updating data-group fails when it doesn't exist so it cannot be deleted
 
 ## [1.3.2] - 2022-3-18
 ## Changed

--- a/src/storageDataGroup.js
+++ b/src/storageDataGroup.js
@@ -78,7 +78,8 @@ function addDataGroup(path) {
 }
 
 function deleteDataGroup(path) {
-    return executeCommand(`tmsh -a delete ltm data-group internal ${path}`);
+    // only attempt a delete if it exists, with one command to avoid race condition
+    return executeCommand(`if tmsh -a list ltm data-group internal ${path} > /dev/null 2>&1; then tmsh -a delete ltm data-group internal ${path}; fi`);
 }
 
 function itemExists(path) {
@@ -130,6 +131,7 @@ function updateDataGroup(path, records) {
                 return resolve();
             });
         }))
+        // merging the config will overwrite the existing data-group
         .then(() => deleteDataGroup(path))
         .then(() => executeCommand(`tmsh -a load sys config merge file ${configFileName}`))
         .then(() => new Promise((resolve, reject) => {


### PR DESCRIPTION
There is a race condition where a second call to updateDataGroup tries to delete the data-group before updating it, but it doesn't exist because the first call is not yet done. This results in an error that prevents the rest of the update code from being executed.

I have combined the check for an existing data-group, and only then delete, in to one command to prevent the error and the race condition. I tried other ways to solve this but found errors when it was attempting to create the data-group (tmsh create) when it already exists, but not with this single command.

The load sys config file merge command will overwrite the existing data-group, so the delete is probably not necessary. You might want to remove that, and/or you might want to create a similar fix for the tmsh create commands.