### PR TITLE
Autotool 3523 service discovery script failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 coverage
 .nyc_output
 .vscode
+jsonconfig.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.X.X] - 2022-X-XX
 
+## [1.3.4] - 2022-10-24
+- More handling for race condition where updating data-group fails when it doesn't exist so it cannot be deleted
+
 ## [1.3.3] - 2022-5-5
 ## Changed
 - Updated the release process documentation

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@f5devcentral/atg-storage",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@f5devcentral/atg-storage",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "author": "F5 Networks",
   "license": "Apache-2.0",
   "main": "index.js",

--- a/test/storageDataGroup.js
+++ b/test/storageDataGroup.js
@@ -337,7 +337,7 @@ describe('StorageDataGroup', () => {
     });
 
     describe('.deleteItem()', () => {
-        let data = [
+        const data = [
             'ltm data-group internal /storage/data-store {',
             '    records {',
             '        hello0 {',


### PR DESCRIPTION
We occasionally run into an error during integration testing because we are trying to delete a data-group that does not exist. Even though we currently check for existence prior to deletion, a race condition still exists where the deferred save timer can fire between checking for existence and attempted deletion.

This PR ignores the 'was not found' error when deleting a data-group.