### PR TITLE
Remove auth header from requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.X.X] - 2022-X-XX
 
+## [1.3.5] - 2022-12-7
+## Changed
+ - Remove auth header when making requests to port 8100 with http. The request module will properly handle the default (which might not be admin)
+
 ## [1.3.4] - 2022-10-24
 - More handling for race condition where updating data-group fails when it doesn't exist so it cannot be deleted
 

--- a/src/storageDataGroup.js
+++ b/src/storageDataGroup.js
@@ -203,7 +203,6 @@ function waitForCompletion(path, remainingRetries) {
         method: 'GET',
         why: 'checking for task completion',
         headers: {
-            Authorization: `Basic ${Buffer.from('admin:').toString('base64')}`,
             'Content-Type': 'application/json'
         }
     };
@@ -438,7 +437,6 @@ class StorageDataGroup {
                     path: '/mgmt/tm/task/sys/config',
                     method: 'POST',
                     headers: {
-                        Authorization: `Basic ${Buffer.from('admin:').toString('base64')}`,
                         'Content-Type': 'application/json'
                     }
                 };
@@ -460,7 +458,6 @@ class StorageDataGroup {
                     path: `/mgmt/tm/task/sys/config/${taskId}`,
                     method: 'PUT',
                     headers: {
-                        Authorization: `Basic ${Buffer.from('admin:').toString('base64')}`,
                         'Content-Type': 'application/json'
                     }
                 };


### PR DESCRIPTION
Leave default auth up to the request module.

It is possible to disable the default admin user and replace it with another user that has admin privileges. The `@f5devcentral/atg-shared-utilities/request` module already inserts `admin` in as the user in the case when protocol is `http` and port is `8100` so the code here is redundant anyway. The `@f5devcentral/atg-shared-utilities/request` module is being updated to get the actual admin user from the system.