### PR TITLE
fix: space in data-group record names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [1.X.X] - 2023-X-XX
+## Fixed
+ - EC-386: Multiple data group records created from one that is named with spaces
 
 ## [1.3.9] - 2023-4-25
 ## Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,8 @@ To check unit test coverage run: `npm run coverage`
 
 To run the linter run: `npm run lint`
 
+* Note: Node v14 or lower must be used when running source tests. Newer versions of Node will result in an Uncaught TypeError due to constraints involving the Nock package version. Consider using Node Version Manager (NVM) to quickly switch between Node versions.
+
 ## How to submit changes
 Thank you for considering contributing changes to this repository.
 If you have some changes you wish to submit, please fork the repository and submit a pull request.

--- a/src/storageDataGroup.js
+++ b/src/storageDataGroup.js
@@ -113,7 +113,7 @@ function dataGroupExists(path) {
 
 function updateDataGroup(path, records) {
     const tmshRecords = records
-        .map(record => `${record.name} { data ${record.data} }`)
+        .map(record => `"${record.name}" { data ${record.data} }`)
         .join('\n        ')
         .replace(/{ /g, '{\n            ')
         .replace(/ }/g, '\n        }');
@@ -161,7 +161,7 @@ function readDataGroup(path) {
 function outputToObject(output) {
     const jsonString = output
         .replace(/ltm data-group internal .*? {/, '{')
-        .replace(/(\s*)(.*?) {/g, '$1"$2" : {')
+        .replace(/(\s*)("?)(.*?)("?) {/g, '$1"$3" : {')
         .replace(/( {8}})(\s*")/gm, '$1,$2')
         .replace(/(\s*)data (.*?)(\s*)}/gm, '$1"data": "$2"$3}')
         .replace(/^( {4}})/m, '$1,')


### PR DESCRIPTION
When adding a record to a data-group, it will create multiple records from a name with spaces, and it will only add data to the last record. 

This will create a single record, preserving the original name with its spaces.